### PR TITLE
Add types reference to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
     "LICENSE",
     "src/lib/index.d.ts"
   ],
-  "types": "src/lib/index.d.ts",
+  "types": "./src/lib/index.d.ts",
   "main": "./dist/react-fi.cjs",
   "module": "./dist/react-fi.js",
   "exports": {
     ".": {
+      "types": "./src/lib/index.d.ts",
       "import": "./dist/react-fi.js",
       "require": "./dist/react-fi.cjs"
     }


### PR DESCRIPTION
Support typescript 5's `moduleResolution` to `bundler`.
https://github.com/microsoft/TypeScript/issues/52363